### PR TITLE
Smoother reordering

### DIFF
--- a/ReOrderingTableViewCellExample/ViewController.m
+++ b/ReOrderingTableViewCellExample/ViewController.m
@@ -69,7 +69,7 @@
 - (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath
 {
     [dataArray exchangeObjectAtIndex:sourceIndexPath.row withObjectAtIndex:destinationIndexPath.row];
-    [self.mTableView reloadData];
+    [self.mTableView moveRowAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath];
 }
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];


### PR DESCRIPTION
I used -moveRowAtIndexPath:toIndexPath: instead of -reloadData to make the reordering animation a bit smoother.
